### PR TITLE
Improved or rewritten - you decide ;)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     rspec-support (3.10.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/lib/phone_plan.rb
+++ b/lib/phone_plan.rb
@@ -1,30 +1,78 @@
+require 'forwardable'
+
 class PhonePlan
-  def initialize(number_of_phones:, price:, type:)
+  extend Forwardable
+
+  def_delegators :@flexible_plan, :cost
+  def_delegators :@flexible_plan, :price
+  def_delegators :@flexible_plan, :per_phone_matrix
+  def_delegators :@flexible_plan, :discount_matrix
+
+  attr_accessor :type
+
+  def initialize(number_of_phones:, price:, type:, per_phone_matrix: nil, discount_matrix: nil)
+    @type = type
+    @flexible_plan = case type
+                     when 'family'
+                       # Hardwired plans mapped to flexible ones
+                       # Family plan - no discounts, additional phones @ £10
+                       FlexiblePhonePlan.new(number_of_phones: number_of_phones,
+                                             price: price,
+                                             per_phone_matrix: { 1 => price, 2 => 10 })
+                     when 'business'
+                       # Business plan - discount % only
+                       FlexiblePhonePlan.new(number_of_phones: number_of_phones,
+                                             price: price,
+                                             discount_matrix: { 1 => 0.75, 50 => 0.5 })
+                     else
+                       # Individual and unspecified plans, no discounts, all phones @ price
+                       FlexiblePhonePlan.new(number_of_phones: number_of_phones,
+                                             price: price)
+                     end
+  end
+end
+
+class FlexiblePhonePlan
+  attr_reader :number_of_phones, :price, :per_phone_matrix, :discount_matrix
+
+  # At this stage the matrices should probably be arrays of struct (at least) 
+  # but we aren't writing a billing system - today ;)
+  def initialize(number_of_phones:, price:, per_phone_matrix: { 1 => price }, discount_matrix: {})
     @number_of_phones = number_of_phones
     @price = price
-    @type = type
+    @per_phone_matrix = per_phone_matrix || { 1 => @price }
+    @discount_matrix = discount_matrix || { 1 => 1 }
   end
 
   def cost
-    if type == "individual"
-      number_of_phones * price
-    elsif type == "family"
-      number_of_extra_phones = number_of_phones - 1
-      cost_per_extra_phone = 10
-
-      price + (number_of_extra_phones * cost_per_extra_phone)
-    elsif type == "business"
-      subtotal = number_of_phones * price
-
-      if number_of_phones < 50
-        subtotal * 0.75
-      else
-        subtotal * 0.50
-      end
-    end
+    total_per_phone_cost * discount_break_point
   end
 
   private
 
-  attr_reader :number_of_phones, :price, :type
+  def discount_break_point
+    @discount_matrix.sort.to_h.filter_map do |breakpoint, discount|
+      discount if @number_of_phones >= breakpoint
+    end.last || 1
+  end
+
+  def per_phone_costs
+    phone_cnt = @number_of_phones
+    last_breakpoint = nil
+    cost_spread = @per_phone_matrix.sort.filter_map do |breakpoint, price|
+      if phone_cnt >= breakpoint || !last_breakpoint
+        phone_cnt -= breakpoint
+        last_breakpoint = breakpoint
+        [price, breakpoint]
+      end
+    end
+    cost_spread.last[1] += phone_cnt if phone_cnt.positive?
+    cost_spread
+  end
+
+  def total_per_phone_cost
+    per_phone_costs.inject(0) do |result, stage|
+      result += stage[0] * stage[1]
+    end
+  end
 end


### PR DESCRIPTION
I chose to heavily refactor this.  The original had a hardcoded
decision tree based on potentially flexible "types".  This is a
smell as any charge to these plans would require a re-deployment,
and they are likely to change or require additional plans.

I've implemented a flexible price plan that has the concept of
break points on both number of phones to price and number of phones
to discount.  The old hardcoded plans are mapped to this using
the appropriate break points and the initializer extend to also
accept the break points as arguments.

In the future this would allow the (obvious) extension to allow
price plans to be described in the database and the breakpoints
simply scoped in.

There was also certain - potentially edge - cases that werent explicitly
handled and, although the default action mave have been correct, the
outcome was ambiguous (for example an individual plan with more than one
phone, or a family plan with only 1 phone)

I haven't changed the tests but they should really have explicit
determination of what these edge cases should do also.

As far as the original code is concerned, I would have short cut the
cost if/else ladder with explicit returns of the value - the method is
too long to be obvious that the value is falling through.
The formula for each type could've been pulled in to separate methods
to localize each type/calculation but I would've refactored this
completely before needing to do this.